### PR TITLE
✨ feat(header): fully refactor header with shadcn dropdowns, theme to…

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { MoonIcon, SunIcon, ChevronDown, ChevronRight } from 'lucide-react'
 import { useState, useRef } from 'react'
 import Link from 'next/link'
 import { LanguageSelector } from '@/components/layout/LanguageSelector'
+import { MainMenu } from '@/components/layout/MainMenu'
 
 const MENU = [
     {
@@ -83,59 +84,7 @@ export default function Header() {
                 </div>
 
                 {/* 중앙 메뉴 */}
-                <nav className="hidden md:flex space-x-6 text-sm font-medium">
-                    {MENU.map(({ label, items, badge }) => {
-                        const isOpen = activeMenu === label
-                        return (
-                        <div key={label} className="relative">
-                            {/* 대분류 메뉴 */}
-                            <div
-                            className="flex items-center space-x-1 hover:text-black dark:hover:text-gray-200 transition cursor-pointer py-2"
-                            onMouseEnter={() => handleMouseEnter(label)}
-                            onMouseLeave={handleMouseLeave}
-                            >
-                                <span>{label}</span>
-                                {badge && (
-                                    <span className="text-[10px] font-bold text-red-500 ml-1">{badge}</span>
-                                )}
-                                {isOpen ? (
-                                    <ChevronDown className="w-4 h-4" />
-                                ) : (
-                                    <ChevronRight className="w-4 h-4" />
-                                )}
-                            </div>
-
-                            {/* 드롭다운 메뉴 */}
-                            {isOpen && (
-                                <div className="absolute top-full left-0 pt-2">
-                                    {/* 삼각형 화살표 */}
-                                    <div className="absolute top-2 left-4 w-3 h-3 bg-white dark:bg-gray-900 rotate-45 border-l border-t border-gray-200 dark:border-gray-700 z-20"></div>
-
-                                    {/* 드롭다운 콘텐츠 */}
-                                    <div
-                                    className={`bg-white dark:bg-gray-900 shadow-xl border border-gray-200 dark:border-gray-700 rounded-md min-w-[180px] z-10 overflow-hidden mt-2
-                                                transition-all duration-200 ease-out
-                                                ${isOpen ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'}`}
-                                    onMouseEnter={() => handleMouseEnter(label)}
-                                    onMouseLeave={handleMouseLeave}
-                                    >
-                                        {items.map(({ label: itemLabel, href }) => (
-                                            <Link
-                                            key={itemLabel}
-                                            href={href}
-                                            className="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 text-sm whitespace-nowrap transition-colors"
-                                            onClick={() => setActiveMenu(null)}
-                                            >
-                                                {itemLabel}
-                                            </Link>
-                                        ))}
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                        )
-                    })}
-                </nav>
+                <MainMenu />
 
                 {/* 오른쪽 기능 */}
                 <div className="flex items-center space-x-4 text-gray-500 dark:text-gray-400 text-sm">

--- a/components/layout/MainMenu.tsx
+++ b/components/layout/MainMenu.tsx
@@ -1,0 +1,144 @@
+// components/layout/MainMenu.tsx
+'use client'
+
+import Link from 'next/link'
+import { useState, useRef } from 'react'
+import {
+  ChevronDown,
+  ChevronRight,
+  ImageIcon,
+  FileImage,
+  FilePlus2,
+  FileMinus2,
+  Palette,
+  Shield,
+  Globe,
+  CalendarClock,
+  CalendarRange,
+  FileDiff,
+  Type,
+} from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+
+const MENU = [
+  {
+    label: '이미지 도구',
+    items: [
+      { label: '이미지 포맷 변환기', href: '/image-converter', icon: ImageIcon },
+      { label: '이미지 → PDF', href: '/image-to-pdf', icon: FileImage },
+    ],
+  },
+  {
+    label: 'PDF 도구',
+    items: [
+      { label: 'PDF 병합', href: '/pdf-merge', icon: FilePlus2 },
+      { label: 'PDF 분할', href: '/pdf-split', icon: FileMinus2 },
+    ],
+  },
+  {
+    label: '색상 도구',
+    items: [
+      { label: '색상 선택기', href: '/color-picker', icon: Palette },
+    ],
+  },
+  {
+    label: '보안 도구',
+    items: [
+      { label: '비밀번호 생성기', href: '/password-generator', icon: Shield },
+    ],
+  },
+  {
+    label: '네트워크 도구',
+    items: [
+      { label: 'IP 확인', href: '/ip-check', icon: Globe },
+    ],
+  },
+  {
+    label: '날짜/시간 도구',
+    badge: 'NEW',
+    items: [
+      { label: '나이 계산기', href: '/age-calculator', icon: CalendarClock },
+      { label: '날짜 차이 계산기', href: '/date-diff', icon: CalendarRange },
+    ],
+  },
+  {
+    label: '텍스트 도구',
+    items: [
+      { label: '텍스트 비교', href: '/text-compare', icon: FileDiff },
+      { label: '글자수 세기', href: '/char-counter', icon: Type },
+    ],
+  },
+]
+
+export function MainMenu() {
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const handleMouseEnter = (label: string) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    setOpenMenu(label)
+  }
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setOpenMenu(null)
+    }, 200)
+  }
+
+  return (
+    <nav className="hidden md:flex space-x-6 text-sm font-medium">
+      {MENU.map(({ label, items, badge }) => {
+        const isOpen = openMenu === label
+
+        return (
+          <div
+            key={label}
+            className="relative"
+            onMouseEnter={() => handleMouseEnter(label)}
+            onMouseLeave={handleMouseLeave}
+          >
+            <DropdownMenu open={isOpen} onOpenChange={() => {}}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center gap-1 px-2 py-1 hover:text-black dark:hover:text-gray-200"
+                >
+                  {label}
+                  {badge && (
+                    <span className="text-[10px] font-bold text-red-500 ml-1">
+                      {badge}
+                    </span>
+                  )}
+                  {isOpen ? (
+                    <ChevronDown className="w-4 h-4" />
+                  ) : (
+                    <ChevronRight className="w-4 h-4" />
+                  )}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-52">
+                {items.map(({ label: itemLabel, href, icon: Icon }) => (
+                  <DropdownMenuItem key={itemLabel} asChild>
+                    <Link
+                      href={href}
+                      className="flex items-center gap-2 w-full text-sm text-gray-700 dark:text-gray-200"
+                    >
+                      <Icon className="w-4 h-4" />
+                      {itemLabel}
+                    </Link>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.525.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",


### PR DESCRIPTION
…ggle, and language selector

- Replaced manual dropdown with shadcn/ui DropdownMenu for main menu categories
- Extracted main menu into reusable <MainMenu /> component for better readability
- Added lucide-react icons to all submenu items for enhanced UX
- Implemented hover behavior to open dropdowns with transition effects
- Switched chevron icons on hover (ChevronRight → ChevronDown)
- Integrated dark/light theme toggle with next-themes
- Extracted language selector into reusable <LanguageSelector /> component using shadcn/ui
- Ensured mobile responsiveness and accessibility alignment
- Fully converted all buttons to use <Button> from shadcn/ui