### PR TITLE
feat: Implement hybrid HEIC support in Image Converter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,14 @@
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "heic2any": "^0.0.4",
         "jszip": "^3.10.1",
         "lucide-react": "^0.544.0",
         "next": "15.5.3",
         "pdf-lib": "^1.17.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "sharp": "^0.34.3",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -2541,7 +2543,6 @@
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -2554,7 +2555,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2567,7 +2567,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -2575,7 +2574,6 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -2770,7 +2768,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3895,6 +3892,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -4011,8 +4014,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -5860,7 +5862,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5930,7 +5931,6 @@
       "integrity": "sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.4",
@@ -6120,7 +6120,6 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "heic2any": "^0.0.4",
     "jszip": "^3.10.1",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
     "pdf-lib": "^1.17.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "sharp": "^0.34.3",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/src/app/api/image/convert-heic/route.ts
+++ b/src/app/api/image/convert-heic/route.ts
@@ -1,0 +1,42 @@
+// src/app/api/image/convert-heic/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import sharp from 'sharp';
+
+export async function POST(request: NextRequest) {
+    try {
+        const formData = await request.formData();
+        const file = formData.get('file') as File | null;
+
+        if (!file) {
+            return NextResponse.json({ error: '파일이 없습니다.' }, { status: 400 });
+        }
+
+        // 1. 받은 파일을 컴퓨터가 처리할 수 있는 'Buffer' 형태로 변환합니다.
+        const fileBuffer = Buffer.from(await file.arrayBuffer());
+
+        // 2. sharp로 이미지를 처리합니다.
+        const convertedImageBuffer = await sharp(fileBuffer)
+            .jpeg({ quality: 90 }) // 90% 품질의 JPEG로 변환하라고 명령합니다.
+            .toBuffer(); // 결과를 다시 Buffer 형태로 꺼냅니다.
+
+        const originalFileName = file.name.replace(/\.[^/.]+$/, "");
+        const filename = `${originalFileName}.jpeg`;
+
+        // 3. 변환된 이미지 데이터를 사용자에게 다시 보내줍니다.
+        return new NextResponse(convertedImageBuffer, {
+        status: 200,
+        headers: {
+            'Content-Type': 'image/jpeg',
+            'Content-Disposition': `attachment; filename="${filename}"`,
+        },
+        });
+
+    } catch (error) {
+        console.error('Sharp HEIC 변환 오류:', error);
+        return NextResponse.json(
+            { error: '서버에서 파일을 변환하는 중 오류가 발생했습니다.' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/image/converter/page.tsx
+++ b/src/app/image/converter/page.tsx
@@ -1,126 +1,212 @@
-// src/app/image/converter/page.tsx (최종 기능 구현)
-
 "use client";
 
+import { Button } from '@/components/ui/button';
 import { useState, ChangeEvent, DragEvent, useEffect } from 'react';
 
 export default function ImageConverterPage() {
-  const [originalFile, setOriginalFile] = useState<File | null>(null);
-  const [originalPreviewUrl, setOriginalPreviewUrl] = useState<string>('');
-  const [targetFormat, setTargetFormat] = useState<'jpeg' | 'png' | 'webp'>('jpeg');
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [originalFile, setOriginalFile] = useState<File | null>(null);
+    const [originalPreviewUrl, setOriginalPreviewUrl] = useState<string>('');
+    const [targetFormat, setTargetFormat] = useState<'jpeg' | 'png' | 'webp'>('jpeg');
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [loadingMessage, setLoadingMessage] = useState<string>('');
+    const [heicConversionErrorFile, setHeicConversionErrorFile] = useState<File | null>(null);
 
-  const handleFile = (file: File | null) => {
-    if (file && file.type.startsWith('image/')) {
-      setOriginalFile(file);
-      const previewUrl = URL.createObjectURL(file);
-      setOriginalPreviewUrl(previewUrl);
-    } else {
-      setOriginalFile(null);
-      setOriginalPreviewUrl('');
-      if (file) alert('이미지 파일만 업로드해주세요.');
-    }
-  };
+    const handleFile = async (file: File | null) => {
+        if (!file) {
+            setOriginalFile(null);
+            setOriginalPreviewUrl('');
+            setHeicConversionErrorFile(null);
+            return;
+        }
 
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => { handleFile(e.target.files?.[0] || null); };
-  const handleDragOver = (e: DragEvent<HTMLElement>) => { e.preventDefault(); };
-  const handleDrop = (e: DragEvent<HTMLElement>) => { e.preventDefault(); handleFile(e.dataTransfer.files?.[0] || null); };
+        const isHeic = file.type === 'image/heic' || file.type === 'image/heif' || file.name.toLowerCase().endsWith('.heic') || file.name.toLowerCase().endsWith('.heif');
+        let processedFile = file;
 
-  // 👇 포맷 변환 및 다운로드 로직
-  const handleConvert = () => {
-    if (!originalPreviewUrl || !originalFile) return;
-
-    setIsLoading(true);
-    const img = new Image();
-    img.onload = () => {
-      const canvas = document.createElement('canvas');
-      // 캔버스 크기를 원본 이미지와 동일하게 설정
-      canvas.width = img.width;
-      canvas.height = img.height;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        setIsLoading(false);
-        return;
-      }
-      
-      // 캔버스에 이미지를 그립니다.
-      ctx.drawImage(img, 0, 0);
-      
-      // 캔버스의 내용을 원하는 포맷의 데이터 URL로 변환합니다.
-      const dataUrl = canvas.toDataURL(`image/${targetFormat}`, 1.0);
-      
-      // 익숙한 다운로드 로직
-      const a = document.createElement('a');
-      a.href = dataUrl;
-      const originalFileName = originalFile.name.replace(/\.[^/.]+$/, "");
-      a.download = `${originalFileName}.${targetFormat}`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      
-      setIsLoading(false);
+        if (isHeic) {
+            setLoadingMessage('HEIC 파일을 변환 중입니다 (브라우저)...');
+            setIsLoading(true);
+            try {
+                const heic2any = (await import('heic2any')).default;
+                const convertedBlob = await heic2any({
+                    blob: file,
+                    toType: "image/jpeg",
+                    quality: 0.9,
+                }) as Blob;
+                
+                const fileName = file.name.replace(/\.[^/.]+$/, ".jpg");
+                processedFile = new File([convertedBlob], fileName, { type: 'image/jpeg' });
+                
+            } catch (error) {
+                console.error("클라이언트 HEIC 변환 오류:", error);
+                setHeicConversionErrorFile(file);
+                setIsLoading(false);
+                setLoadingMessage('');
+                return;
+            } finally {
+                setIsLoading(false);
+                setLoadingMessage('');
+            }
+        }
+        
+        if (processedFile.type.startsWith('image/')) {
+            setOriginalFile(processedFile);
+            setHeicConversionErrorFile(null);
+            const previewUrl = URL.createObjectURL(processedFile);
+            setOriginalPreviewUrl(previewUrl);
+        } else {
+            alert('이미지 파일만 업로드해주세요.');
+        }
     };
-    img.src = originalPreviewUrl;
-  };
 
-  useEffect(() => {
-    return () => { if (originalPreviewUrl) { URL.revokeObjectURL(originalPreviewUrl); } };
-  }, [originalPreviewUrl]);
+    const handleServerRetry = async () => {
+        if (!heicConversionErrorFile) return;
 
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="text-center mb-8">
-        <h1 className="text-4xl font-black tracking-tighter">이미지 포맷 변환</h1>
-        <p className="text-lg text-gray-600 mt-2">
-          이미지를 JPG, PNG, WEBP 포맷으로 변환하세요.
-        </p>
-      </div>
+        setLoadingMessage('서버에서 변환을 재시도합니다...');
+        setIsLoading(true);
+        setHeicConversionErrorFile(null);
 
-      {!originalFile && (
-        <div className="w-full max-w-2xl mx-auto" onDragOver={handleDragOver} onDrop={handleDrop}>
-          <label htmlFor="file-upload" className="flex flex-col items-center justify-center w-full h-64 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors">
-            {/* ... SVG 아이콘 등은 동일 ... */}
-            <p>이미지 파일을 이곳에 드롭하거나 클릭하여 업로드하세요</p>
-            <input id="file-upload" type="file" className="hidden" accept="image/*" onChange={handleFileChange} />
-          </label>
-        </div>
-      )}
+        const formData = new FormData();
+        formData.append('file', heicConversionErrorFile);
 
-      {originalFile && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">원본 이미지</h2>
-            <div className="border rounded-lg p-2 bg-gray-50 flex items-center justify-center min-h-[200px]">
-              {originalPreviewUrl && (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={originalPreviewUrl} alt="Original Preview" className="max-w-full max-h-96 rounded" />
-              )}
+        try {
+            const response = await fetch('/api/image/convert-heic', {
+                method: 'POST',
+                body: formData,
+            });
+            if (!response.ok) throw new Error('서버 변환 실패');
+
+            const convertedBlob = await response.blob();
+            const fileName = heicConversionErrorFile.name.replace(/\.[^/.]+$/, ".jpeg");
+            const convertedFile = new File([convertedBlob], fileName, { type: 'image/jpeg' });
+            
+            handleFile(convertedFile);
+        } catch (error) {
+            console.error('서버 HEIC 변환 오류:', error);
+            alert('서버에서도 파일 변환에 실패했습니다. 다른 파일을 이용해주세요.');
+            setOriginalFile(null);
+            setOriginalPreviewUrl('');
+        } finally {
+            setIsLoading(false);
+            setLoadingMessage('');
+        }
+    };
+    
+    const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => { handleFile(e.target.files?.[0] || null); };
+    const handleDragOver = (e: DragEvent<HTMLElement>) => { e.preventDefault(); };
+    const handleDrop = (e: DragEvent<HTMLElement>) => { e.preventDefault(); handleFile(e.dataTransfer.files?.[0] || null); };
+
+    const handleConvert = () => {
+        if (!originalPreviewUrl || !originalFile) return;
+        setIsLoading(true);
+        setLoadingMessage('포맷 변환 중...');
+        const img = new Image();
+        img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = img.width;
+            canvas.height = img.height;
+            const ctx = canvas.getContext('2d');
+
+            if (!ctx) {
+                setIsLoading(false);
+                return;
+            }
+
+            ctx.drawImage(img, 0, 0);
+            const dataUrl = canvas.toDataURL(`image/${targetFormat}`, 1.0);
+            const a = document.createElement('a');
+            a.href = dataUrl;
+            const originalFileName = originalFile.name.replace(/\.[^/.]+$/, "");
+            a.download = `${originalFileName}.${targetFormat}`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            setIsLoading(false);
+            setLoadingMessage('');
+        };
+        img.src = originalPreviewUrl;
+    };
+
+    useEffect(() => {
+        return () => { if (originalPreviewUrl) { URL.revokeObjectURL(originalPreviewUrl); } };
+    }, [originalPreviewUrl]);
+
+    return (
+        <div className="container mx-auto px-4 py-8">
+            <div className="text-center mb-8">
+                <h1 className="text-4xl font-black tracking-tighter">이미지 포맷 변환</h1>
+                <p className="text-lg text-gray-600 mt-2">
+                    이미지를 JPG, PNG, WEBP 포맷으로 변환하세요.
+                </p>
             </div>
-          </div>
-          
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">변환 옵션</h2>
-            <div className="border rounded-lg p-4 bg-white space-y-4 shadow-sm">
-              <div>
-                <label className="text-sm font-medium">변환할 포맷</label>
-                <div className="flex items-center gap-6 mt-2">
-                  <label className="flex items-center"><input type="radio" name="format" value="jpeg" checked={targetFormat === 'jpeg'} onChange={() => setTargetFormat('jpeg')} className="h-4 w-4 text-indigo-600 border-gray-300" /> <span className="ml-2">JPG</span></label>
-                  <label className="flex items-center"><input type="radio" name="format" value="png" checked={targetFormat === 'png'} onChange={() => setTargetFormat('png')} className="h-4 w-4 text-indigo-600 border-gray-300" /> <span className="ml-2">PNG</span></label>
-                  <label className="flex items-center"><input type="radio" name="format" value="webp" checked={targetFormat === 'webp'} onChange={() => setTargetFormat('webp')} className="h-4 w-4 text-indigo-600 border-gray-300" /> <span className="ml-2">WEBP</span></label>
+
+            {isLoading && (
+                <div className="text-center py-10">
+                    <p className="text-lg font-semibold">{loadingMessage || '처리 중...'}</p>
                 </div>
-              </div>
+            )}
 
-              <button 
-                onClick={handleConvert}
-                disabled={isLoading}
-                className="w-full px-6 py-3 bg-gray-900 text-white font-semibold rounded-lg hover:bg-gray-700 transition-colors disabled:bg-gray-400"
-              >
-                {isLoading ? '변환 중...' : '포맷 변환 & 다운로드'}
-              </button>
-            </div>
-          </div>
+            {!originalFile && !isLoading && !heicConversionErrorFile && (
+                <div className="w-full max-w-2xl mx-auto" onDragOver={handleDragOver} onDrop={handleDrop}>
+                    <label htmlFor="file-upload" className="flex flex-col items-center justify-center w-full h-64 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors">
+                        <svg className="w-10 h-10 mb-4 text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 16">
+                            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 13h3a3 3 0 0 0 0-6h-.025A5.56 5.56 0 0 0 16 6.5 5.5 5.5 0 0 0 5.207 5.021C5.137 5.017 5.071 5 5 5a4 4 0 0 0 0 8h2.167M10 15V6m0 0L8 8m2-2 2 2"/>
+                        </svg>
+                        <p>이미지 파일(HEIC 포함)을 드롭하거나 클릭하여 업로드하세요</p>
+                        <input id="file-upload" type="file" className="hidden" accept="image/*,.heic,.heif" onChange={handleFileChange} />
+                    </label>
+                </div>
+            )}
+
+            {heicConversionErrorFile && !isLoading && (
+                <div className="w-full max-w-2xl mx-auto text-center p-8 border rounded-lg bg-yellow-50 border-yellow-200">
+                    <h3 className="text-lg font-semibold text-yellow-800">브라우저에서 변환 실패</h3>
+                    <p className="text-yellow-700 my-2">이 HEIC 파일은 브라우저에서 직접 변환할 수 없는 형식입니다.</p>
+                    <p className="text-sm text-yellow-600 mb-4">파일명: {heicConversionErrorFile.name}</p>
+                    <Button onClick={handleServerRetry} className="px-6 py-3 bg-yellow-500 text-white font-bold rounded-lg shadow-md hover:bg-yellow-600">
+                        더 강력한 서버에서 재시도
+                    </Button>
+                </div>
+            )}
+
+            {(originalFile && !isLoading && !heicConversionErrorFile) && (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+                    <div className="space-y-4">
+                        <h2 className="text-lg font-semibold">원본 이미지</h2>
+                        <div className="border rounded-lg p-2 bg-gray-50 flex items-center justify-center min-h-[200px]">
+                            {originalPreviewUrl && (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img src={originalPreviewUrl} alt="Original Preview" className="max-w-full max-h-96 rounded" />
+                            )}
+                        </div>
+                    </div>
+                
+                    <div className="space-y-4">
+                        <h2 className="text-lg font-semibold">변환 옵션</h2>
+                        <div className="border rounded-lg p-4 bg-white space-y-4 shadow-sm">
+                            <div>
+                                <label className="text-sm font-medium">변환할 포맷</label>
+                                <div className="flex items-center gap-6 mt-2">
+                                    <label className="flex items-center">
+                                        <input type="radio" name="format" value="jpeg" checked={targetFormat === 'jpeg'} onChange={() => setTargetFormat('jpeg')} className="h-4 w-4 text-indigo-600 border-gray-300" />
+                                        <span className="ml-2">JPG</span>
+                                    </label>
+                                    <label className="flex items-center">
+                                        <input type="radio" name="format" value="png" checked={targetFormat === 'png'} onChange={() => setTargetFormat('png')} className="h-4 w-4 text-indigo-600 border-gray-300" />
+                                        <span className="ml-2">PNG</span>
+                                    </label>
+                                    <label className="flex items-center">
+                                        <input type="radio" name="format" value="webp" checked={targetFormat === 'webp'} onChange={() => setTargetFormat('webp')} className="h-4 w-4 text-indigo-600 border-gray-300" />
+                                        <span className="ml-2">WEBP</span>
+                                    </label>
+                                </div>
+                            </div>
+                            <Button onClick={handleConvert} disabled={isLoading} className="w-full px-6 py-3 bg-gray-900 text-white font-semibold rounded-lg hover:bg-gray-700 transition-colors disabled:bg-gray-400">
+                                {isLoading ? loadingMessage : '포맷 변환 & 다운로드'}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
이미지 포맷 변환기에 HEIC 파일 지원 기능을 추가합니다. 클라이언트와 서버를 모두 사용하는 하이브리드 방식을 적용하여 변환 성공률을 높였습니다.

주요 구현 내용:
- 1차적으로 heic2any를 이용한 클라이언트 사이드 변환 시도
- 클라이언트 변환 실패 시, sharp를 이용한 서버 사이드 변환 재시도 옵션 제공
- 서버 사이드 변환을 위한 /api/image/convert-heic API 엔드포인트 생성

알려진 이슈:
- 로컬 개발 환경에서는 sharp의 HEIC 디코더 부재로 서버 변환이 실패할 수 있음. 배포 후 최종 테스트 필요.