### PR TITLE
fix(api): Resolve build errors for Vercel deployment

### DIFF
--- a/src/app/api/pdf/merge/route.ts
+++ b/src/app/api/pdf/merge/route.ts
@@ -1,11 +1,10 @@
-// src/app/api/pdf/merge/route.ts
+// src/app/api/pdf/merge/route.ts (수정 완료)
 
 import { NextRequest, NextResponse } from 'next/server';
 import { PDFDocument } from 'pdf-lib';
 
 export async function POST(request: NextRequest) {
     try {
-        // 1. 프론트엔드에서 보낸 파일들을 FormData 형식으로 받습니다.
         const formData = await request.formData();
         const files = formData.getAll('files') as File[];
 
@@ -13,10 +12,8 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ error: '파일이 없습니다.' }, { status: 400 });
         }
 
-        // 2. 새로운 PDF 문서를 생성합니다. 여기가 결과물이 담길 빈 종이입니다.
         const mergedPdf = await PDFDocument.create();
 
-        // 3. 받은 파일들을 하나씩 순회하면서 새 문서에 페이지를 복사합니다.
         for (const file of files) {
             const arrayBuffer = await file.arrayBuffer();
             const pdf = await PDFDocument.load(arrayBuffer);
@@ -26,10 +23,11 @@ export async function POST(request: NextRequest) {
             });
         }
 
-        // 4. 합쳐진 PDF를 바이트 배열(Uint8Array)로 저장합니다.
         const mergedPdfBytes = await mergedPdf.save();
 
-        // 👇 파일명을 위한 타임스탬프 생성 로직 추가
+        // 👇 Uint8Array를 표준 ArrayBuffer로 변환합니다.
+        const arrayBuffer = new Uint8Array(mergedPdfBytes).buffer;
+
         const now = new Date();
         const year = now.getFullYear();
         const month = String(now.getMonth() + 1).padStart(2, '0');
@@ -41,8 +39,8 @@ export async function POST(request: NextRequest) {
         const timestamp = `${year}${month}${day}_${hours}${minutes}${seconds}`;
         const filename = `toolverse-merged_${timestamp}.pdf`;
 
-        // 5. 성공적으로 합쳐진 PDF 파일을 응답으로 보내줍니다.
-        return new NextResponse(mergedPdfBytes, {
+        // 👇 변환된 arrayBuffer를 사용합니다.
+        return new NextResponse(arrayBuffer, {
             status: 200,
             headers: {
                 'Content-Type': 'application/pdf',


### PR DESCRIPTION
Vercel 빌드 환경에서의 타입스크립트 오류를 해결하여 배포를 성공적으로 완료합니다.

주요 수정 내용:
- `NextResponse`의 BodyInit 타입과 호환되지 않는 Node.js `Buffer` 및 `Uint8Array` 타입을 표준 `ArrayBuffer`로 명시적으로 변환했습니다.
- 이 수정은 `pdf-lib`, `sharp`, `jszip` 라이브러리를 사용하는 모든 API Route(PDF 합치기, 이미지 변환/압축/파비콘 생성 등)에 적용되었습니다.
- 이를 통해 로컬 개발 환경에서는 드러나지 않던 타입 안정성 문제를 해결하고, 프로덕션 빌드가 정상적으로 완료되도록 보장합니다.