### PR TITLE
fix(api): Resolve NextResponse type errors for Vercel deployment

### DIFF
--- a/src/app/api/pdf/reorder/route.ts
+++ b/src/app/api/pdf/reorder/route.ts
@@ -27,10 +27,15 @@ export async function POST(request: NextRequest) {
         copiedPages.forEach(page => newPdf.addPage(page));
 
         const newPdfBytes = await newPdf.save();
+
+        // 👇 이 한 줄을 추가하여 Uint8Array를 표준 ArrayBuffer로 변환합니다.
+        const arrayBuffer = new Uint8Array(newPdfBytes).buffer;
+
         const timestamp = new Date().toISOString().replace(/[-:.]/g, '');
         const filename = `toolverse-reordered_${timestamp}.pdf`;
 
-        return new NextResponse(newPdfBytes, {
+        // 👇 변환된 arrayBuffer를 사용합니다.
+        return new NextResponse(arrayBuffer, {
             status: 200,
             headers: {
                 'Content-Type': 'application/pdf',


### PR DESCRIPTION
Vercel 빌드 환경에서 NextResponse가 Buffer/Uint8Array 타입을 제대로 처리하지 못해 발생하던 빌드 에러를 해결합니다.

주요 수정 내용:
- pdf-lib, sharp, jszip 라이브러리를 사용하는 모든 API Route에서 반환하는 데이터 타입을, NextResponse가 안전하게 처리할 수 있는 표준 ArrayBuffer로 명시적으로 변환했습니다.
- 이를 통해 로컬 개발 환경에서는 드러나지 않던 타입 안정성 문제를 해결하고, 프로덕션 빌드가 정상적으로 완료되도록 보장합니다.