### PR TITLE
chore: Refactor tailwind config to use ES module import

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from "tailwindcss"
+import animate from "tailwindcss-animate"
 
 const config = {
-    darkMode: ["class"],
+    darkMode: "class",
     content: [
         './pages/**/*.{ts,tsx}',
         './components/**/*.{ts,tsx}',
@@ -34,7 +35,7 @@ const config = {
             },
         },
     },
-    plugins: [require("tailwindcss-animate")],
+    plugins: [animate],
 } satisfies Config
 
 export default config


### PR DESCRIPTION
ESLint 규칙(@typescript-eslint/no-require-imports)을 준수하기 위해 `tailwind.config.ts` 파일 내의 `require()` 구문을 ES 모듈 `import` 구문으로 변경합니다.

이를 통해 프로젝트 전체의 코드 스타일 일관성을 향상시킵니다.